### PR TITLE
Add min, max, pow methods for packs

### DIFF
--- a/psimd/psimd.h
+++ b/psimd/psimd.h
@@ -808,6 +808,42 @@ namespace psimd {
     return result;
   }
 
+  template <typename T, int W>
+  inline pack<T, W> pow(const pack<T, W> &v, const float b)
+  {
+    pack<T, W> result;
+
+    #pragma omp simd
+    for (int i = 0; i < W; ++i)
+      result[i] = std::pow(v[i], b);
+
+    return result;
+  }
+
+  template <typename T, int W>
+  inline pack<T, W> max(const pack<T, W> &a, const pack<T, W> &b)
+  {
+    pack<T, W> result;
+
+    #pragma omp simd
+    for (int i = 0; i < W; ++i)
+      result[i] = std::max(a[i], b[i]);
+
+    return result;
+  }
+
+  template <typename T, int W>
+  inline pack<T, W> min(const pack<T, W> &a, const pack<T, W> &b)
+  {
+    pack<T, W> result;
+
+    #pragma omp simd
+    for (int i = 0; i < W; ++i)
+      result[i] = std::min(a[i], b[i]);
+
+    return result;
+  }
+
   // pack<> algorithms ////////////////////////////////////////////////////////
 
   template <typename T, int W, typename FCN_T>


### PR DESCRIPTION
When porting micro-packet to psimd I noticed I needed min/max/pow methods on the packs which weren't provided. This PR adds them.

Also check it out https://github.com/Twinklebear/micro-packet/tree/psimd 👍 